### PR TITLE
Unscoped Updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+
+[*.{rb,erb,coffee,yml,sh,js,json,html,css,scss}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Gemfile]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ The model can have several options set:
 
 [__except__](#except)
 
+[__unscoped_updates__](#unscoped_updates)
+
 #### <a id="salesforce_sync_enabled"></a>salesforce_sync_enabled
 Model level option to enable disable the sync, defaults to true.
 
@@ -244,6 +246,14 @@ method is given then only the salesforce_skip_sync attribute is used. Defaults t
 
 ````ruby
 :except => :except_method_name
+````
+
+#### unscoped_updates
+Enable bypassing the default scope when searching for records to update.  This is useful when using a
+soft deletion strategy that can respect SF undeletion.
+
+````ruby
+:unscoped_updates => true
 ````
 
 ### Stopping the Sync
@@ -427,6 +437,16 @@ This is done using the :sync_outbound_delete option, which can take either a boo
 
   def outbound_delete
     return self.is_trial_user?
+  end
+```
+
+### Soft Deletes
+Setting unscoped_updates to true will permit you to find deleted objects to sync changes to.  You can implement virtual attributes matching the
+undelete field in SF to implement the soft deletion strategy of your choosing.  For the paranoia gem:
+
+```ruby
+  def undeleted=(value)
+    restore if value
   end
 ```
 

--- a/app/controllers/salesforce_ar_sync/soap_message_controller.rb
+++ b/app/controllers/salesforce_ar_sync/soap_message_controller.rb
@@ -1,7 +1,9 @@
 module SalesforceArSync
   class SoapMessageController < ::ApplicationController
+
+    protect_from_forgery with: :null_session
     before_filter :validate_ip_ranges
-    
+
     def sync_object
       delayed_soap_handler SalesforceArSync::SoapHandler::Base
     end

--- a/lib/salesforce_ar_sync/extenders/salesforce_syncable.rb
+++ b/lib/salesforce_ar_sync/extenders/salesforce_syncable.rb
@@ -17,6 +17,7 @@ module SalesforceArSync
 
         self.sync_inbound_delete = options.has_key?(:sync_inbound_delete) ? options[:sync_inbound_delete] : true
         self.sync_outbound_delete = options.has_key?(:sync_outbound_delete) ? options[:sync_outbound_delete] : false
+        self.unscoped_updates = options.has_key?(:unscoped_updates) ? options[:unscoped_updates] : false
 
         self.salesforce_object_name_method = options.has_key?(:salesforce_object_name) ? options[:salesforce_object_name] : nil
         self.salesforce_skip_sync_method = options.has_key?(:except) ? options[:except] : nil


### PR DESCRIPTION
Adds a flag to enable bypassing the default scope when updating objects; useful for handling undelete messages with soft-delete implementations