### PR TITLE
Alias Delete Objects Via Config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem "appraisal"
+gem 'appraisal'

--- a/app/controllers/salesforce_ar_sync/soap_message_controller.rb
+++ b/app/controllers/salesforce_ar_sync/soap_message_controller.rb
@@ -15,13 +15,11 @@ module SalesforceArSync
     private
 
     def delayed_soap_handler (klass, priority = 90)
-      begin
-        soap_handler = klass.new(SalesforceArSync.config["ORGANIZATION_ID"], params)
-        soap_handler.process_notifications(priority) if soap_handler.sobjects
-        render :xml => soap_handler.generate_response, :status => :created
-      rescue Exception => ex
-        render :xml => soap_handler.generate_response(ex), :status => :created
-      end
+      soap_handler = klass.new(SalesforceArSync.config['ORGANIZATION_ID'], params)
+      soap_handler.process_notifications(priority) if soap_handler.sobjects
+      render xml: soap_handler.generate_response, status: :created
+    rescue => ex
+      render xml: soap_handler.generate_response(ex), status: :created
     end
 
     # to be used in a before_filter, checks ip ranges specified in configuration

--- a/lib/salesforce_ar_sync/engine.rb
+++ b/lib/salesforce_ar_sync/engine.rb
@@ -1,29 +1,31 @@
 module SalesforceArSync
   class Engine < ::Rails::Engine
-    initializer "salesforce_ar_sync.load_app_instance_data" do |app|
+    initializer 'salesforce_ar_sync.load_app_instance_data' do |app|
       SalesforceArSync.setup do |config|
         config.app_root = app.root
-        
-        #Load the configuration from the environment or a yaml file or disable it if no config present
-        SalesforceArSync.config = Hash.new
-        #load the config file if we have it
+
+        # Load the configuration from the environment or a yaml file or disable it if no config present
+        SalesforceArSync.config = {}
+        # load the config file if we have it
         if FileTest.exist?("#{Rails.root}/config/salesforce_ar_sync.yml")
           config = YAML.load_file("#{Rails.root}/config/salesforce_ar_sync.yml")[Rails.env]
-          SalesforceArSync.config["ORGANIZATION_ID"] = config['organization_id']
-          SalesforceArSync.config["SYNC_ENABLED"] = config['sync_enabled']
-          SalesforceArSync.config["IP_RANGES"] = config['ip_ranges'].split(',').map{ |ip| ip.strip }
-          SalesforceArSync.config["NAMESPACE_PREFIX"] = config['namespace_prefix']
+          SalesforceArSync.config['ORGANIZATION_ID'] = config['organization_id']
+          SalesforceArSync.config['SYNC_ENABLED'] = config['sync_enabled']
+          SalesforceArSync.config['IP_RANGES'] = config['ip_ranges'].split(',').map(&:strip)
+          SalesforceArSync.config['NAMESPACE_PREFIX'] = config['namespace_prefix']
+          SalesforceArSync.config['DELETION_MAP'] = config['deletion_map'].stringify_keys
         end
 
-        #if we have ENV flags prefer them
-        SalesforceArSync.config["ORGANIZATION_ID"] = ENV["SALESFORCE_AR_SYNC_ORGANIZATION_ID"] if ENV["SALESFORCE_AR_SYNC_ORGANIZATION_ID"]
-        SalesforceArSync.config["SYNC_ENABLED"] = ENV["SALESFORCE_AR_SYNC_SYNC_ENABLED"] if ENV.include? "SALESFORCE_AR_SYNC_SYNC_ENABLED"
-        SalesforceArSync.config["IP_RANGES"] = ENV["SALESFORCE_AR_SYNC_IP_RANGES"].split(',').map{ |ip| ip.strip } if ENV["SALESFORCE_AR_SYNC_IP_RANGES"]
-        SalesforceArSync.config["NAMESPACE_PREFIX"] = ENV["SALESFORCE_AR_NAMESPACE_PREFIX"] if ENV["SALESFORCE_AR_NAMESPACE_PREFIX"]
+        # if we have ENV flags prefer them
+        SalesforceArSync.config['ORGANIZATION_ID'] = ENV['SALESFORCE_AR_SYNC_ORGANIZATION_ID'] if ENV['SALESFORCE_AR_SYNC_ORGANIZATION_ID']
+        SalesforceArSync.config['SYNC_ENABLED'] = ENV['SALESFORCE_AR_SYNC_SYNC_ENABLED'] if ENV.include? 'SALESFORCE_AR_SYNC_SYNC_ENABLED'
+        SalesforceArSync.config['IP_RANGES'] = ENV['SALESFORCE_AR_SYNC_IP_RANGES'].split(',').map(&:strip) if ENV['SALESFORCE_AR_SYNC_IP_RANGES']
+        SalesforceArSync.config['NAMESPACE_PREFIX'] = ENV['SALESFORCE_AR_NAMESPACE_PREFIX'] if ENV['SALESFORCE_AR_NAMESPACE_PREFIX']
+        SalesforceArSync.config['DELETION_MAP'] = ENV['DELETION_MAP'] if ENV['DELETION_MAP']
 
-        #do we have valid config options now?
-        if !SalesforceArSync.config["ORGANIZATION_ID"].present? || SalesforceArSync.config["ORGANIZATION_ID"].length != 18
-          SalesforceArSync.config["SYNC_ENABLED"] = false
+        # do we have valid config options now?
+        if SalesforceArSync.config['ORGANIZATION_ID'].blank? || SalesforceArSync.config['ORGANIZATION_ID'].length != 18
+          SalesforceArSync.config['SYNC_ENABLED'] = false
         end
       end
     end

--- a/lib/salesforce_ar_sync/extenders/salesforce_syncable.rb
+++ b/lib/salesforce_ar_sync/extenders/salesforce_syncable.rb
@@ -5,22 +5,22 @@ module SalesforceArSync
         require 'salesforce_ar_sync/salesforce_sync'
         include SalesforceArSync::SalesforceSync
 
-        self.salesforce_sync_enabled = options.has_key?(:salesforce_sync_enabled) ? options[:salesforce_sync_enabled] : true
-        self.salesforce_sync_attribute_mapping = options.has_key?(:sync_attributes) ? options[:sync_attributes].stringify_keys : {}
-        self.salesforce_async_attributes = options.has_key?(:async_attributes) ? options[:async_attributes] : {}
-        self.salesforce_default_attributes_for_create = options.has_key?(:default_attributes_for_create) ? options[:default_attributes_for_create] : {}
-        self.salesforce_id_attribute_name = options.has_key?(:salesforce_id_attribute_name) ? options[:salesforce_id_attribute_name] : :Id
-        self.salesforce_web_id_attribute_name = options.has_key?(:web_id_attribute_name) ? options[:web_id_attribute_name] : :WebId__c
-        self.activerecord_web_id_attribute_name = options.has_key?(:activerecord_web_id_attribute_name) ? options[:activerecord_web_id_attribute_name] : :id
-        self.salesforce_sync_web_id = options.has_key?(:salesforce_sync_web_id) ? options[:salesforce_sync_web_id] : false
-        self.salesforce_web_class_name = options.has_key?(:web_class_name) ? options[:web_class_name] : self.name
+        self.salesforce_sync_enabled = options.fetch(:salesforce_sync_enabled, true)
+        self.salesforce_sync_attribute_mapping = options.key?(:sync_attributes) ? options[:sync_attributes].stringify_keys : {}
+        self.salesforce_async_attributes = options.fetch(:async_attributes, {})
+        self.salesforce_default_attributes_for_create = options.fetch(:default_attributes_for_create, {})
+        self.salesforce_id_attribute_name = options.fetch(:salesforce_id_attribute_name, :Id)
+        self.salesforce_web_id_attribute_name = options.fetch(:web_id_attribute_name, :WebId__c)
+        self.activerecord_web_id_attribute_name = options.fetch(:activerecord_web_id_attribute_name, :id)
+        self.salesforce_sync_web_id = options.fetch(:salesforce_sync_web_id, false)
+        self.salesforce_web_class_name = options.fetch(:web_class_name, name)
 
-        self.sync_inbound_delete = options.has_key?(:sync_inbound_delete) ? options[:sync_inbound_delete] : true
-        self.sync_outbound_delete = options.has_key?(:sync_outbound_delete) ? options[:sync_outbound_delete] : false
-        self.unscoped_updates = options.has_key?(:unscoped_updates) ? options[:unscoped_updates] : false
+        self.sync_inbound_delete = options.fetch(:sync_inbound_delete, true)
+        self.sync_outbound_delete = options.fetch(:sync_outbound_delete, false)
+        self.unscoped_updates = options.fetch(:unscoped_updates, false)
 
-        self.salesforce_object_name_method = options.has_key?(:salesforce_object_name) ? options[:salesforce_object_name] : nil
-        self.salesforce_skip_sync_method = options.has_key?(:except) ? options[:except] : nil
+        self.salesforce_object_name_method = options.fetch(:salesforce_object_name, nil)
+        self.salesforce_skip_sync_method = options.fetch(:except, nil)
 
         instance_eval do
           before_save :salesforce_sync
@@ -28,7 +28,7 @@ module SalesforceArSync
           after_commit :salesforce_delete_object, on: :destroy
 
           def salesforce_sync_web_id?
-            self.salesforce_sync_web_id
+            salesforce_sync_web_id
           end
         end
 
@@ -37,16 +37,16 @@ module SalesforceArSync
           # If no method is provided, defaults to the class name
           def salesforce_object_name
             return send(self.class.salesforce_object_name_method) if self.class.salesforce_object_name_method.present?
-            return self.class.name
+            self.class.name
           end
 
           # Calls a method, if provided, to determine if a record should be synced to Salesforce.
           # The salesforce_skip_sync instance variable is also used.
           # The SALESFORCE_AR_SYNC_ENABLED flag overrides all the others if set to false
           def salesforce_skip_sync?
-            return true if SalesforceArSync.config["SYNC_ENABLED"] == false
+            return true if SalesforceArSync.config['SYNC_ENABLED'] == false
             return (salesforce_skip_sync || !self.class.salesforce_sync_enabled || send(self.class.salesforce_skip_sync_method)) if self.class.salesforce_skip_sync_method.present?
-            return (salesforce_skip_sync || !self.class.salesforce_sync_enabled)
+            (salesforce_skip_sync || !self.class.salesforce_sync_enabled)
           end
         end
       end

--- a/lib/salesforce_ar_sync/ip_constraint.rb
+++ b/lib/salesforce_ar_sync/ip_constraint.rb
@@ -3,15 +3,15 @@ require 'ipaddr'
 module SalesforceArSync
   class IPConstraint
     def initialize
-    	@ip_ranges = SalesforceArSync.config["IP_RANGES"]
+      @ip_ranges = SalesforceArSync.config['IP_RANGES']
     end
- 
+
     def matches?(request)
-    	if Rails.env == 'development' || Rails.env == 'test'
-  	  	true
-    	else
-    		@ip_ranges.any?{|r| IPAddr.new(r).include?(IPAddr.new(request.remote_ip)) }
-    	end
+      if Rails.env == 'development' || Rails.env == 'test'
+        true
+      else
+        @ip_ranges.any? { |r| IPAddr.new(r).include?(IPAddr.new(request.remote_ip)) }
+      end
     end
   end
 end

--- a/lib/salesforce_ar_sync/salesforce_object_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_object_sync.rb
@@ -1,13 +1,14 @@
 module SalesforceArSync
   # simple object to be serialized when asynchronously sending data to Salesforce
   class SalesforceObjectSync < Struct.new(:web_object_name, :salesforce_id, :attributes)
-    def perform        
+    def perform
       web_object = "#{web_object_name}".constantize.find_by_salesforce_id salesforce_id
-      #object exists in salesforce if we call its system_mod_stamp
-      if (system_mod_stamp = web_object.system_mod_stamp)
-        web_object.salesforce_update_object(web_object.salesforce_attributes_to_update(true))
-        web_object.update_attribute(:salesforce_updated_at, system_mod_stamp)
-      end
+
+      # object exists in salesforce if we call its system_mod_stamp
+      return if system_mod_stamp == web_object.system_mod_stamp
+
+      web_object.salesforce_update_object(web_object.salesforce_attributes_to_update(true))
+      web_object.update_attribute(:salesforce_updated_at, system_mod_stamp)
     end
   end
 end

--- a/lib/salesforce_ar_sync/soap_handler/base.rb
+++ b/lib/salesforce_ar_sync/soap_handler/base.rb
@@ -3,57 +3,63 @@ module SalesforceArSync
     class Base
       attr_reader :xml_hashed, :options, :sobjects
 
-      def initialize organization, options = {}
+      def initialize(_organization, options = {})
         @options = options
         @xml_hashed = options
-        @organization = SalesforceArSync.config["ORGANIZATION_ID"]
+        @organization = SalesforceArSync.config['ORGANIZATION_ID']
         @sobjects = collect_sobjects if valid?
       end
 
       # queues each individual record from the message for update
       def process_notifications(priority = 90)
         batch_process do |sobject|
-          options[:klass].camelize.constantize.delay(:priority => priority, :run_at => 5.seconds.from_now).salesforce_update(sobject)
+          options[:klass].camelize.constantize.delay(priority: priority, run_at: 5.seconds.from_now).salesforce_update(sobject)
         end
       end
 
       # ensures that the received message is properly formed, and that it comes from the expected Salesforce Org
       def valid?
-        notifications = @xml_hashed.try(:[], "Envelope").try(:[], "Body").try(:[], "notifications")
+        notifications = @xml_hashed.try(:[], 'Envelope').try(:[], 'Body').try(:[], 'notifications')
 
-        organization_id = notifications.try(:[], "OrganizationId")
-        return !notifications.try(:[], "Notification").nil? && organization_id == @organization # we sent this to ourselves
+        organization_id = notifications.try(:[], 'OrganizationId')
+        !notifications.try(:[], 'Notification').nil? && organization_id == @organization # we sent this to ourselves
       end
 
       def batch_process(&block)
         return if sobjects.nil? || !block_given?
-        sobjects.each do | sobject |
+        sobjects.each do |sobject|
           yield sobject
         end
       end
 
-      #xml for SFDC response
-      #called from soap_message_controller
-      def generate_response(error = nil)      
+      # xml for SFDC response
+      # called from soap_message_controller
+      def generate_response(error = nil)
         response = "<Ack>#{sobjects.nil? ? false : true}</Ack>" unless error
-        if error 
+        if error
           response = "<soapenv:Fault><faultcode>soap:Receiver</faultcode><faultstring>#{error.message}</faultstring></soapenv:Fault>"
         end
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><soapenv:Body><notificationsResponse>#{response}</notificationsResponse></soapenv:Body></soapenv:Envelope>"
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><soapenv:Body><notificationsResponse>#{response}</notificationsResponse></soapenv:Body></soapenv:Envelope>"
       end
 
       def self.namespaced(field)
-         SalesforceArSync.config["NAMESPACE_PREFIX"].present? ? :"#{SalesforceArSync.config["NAMESPACE_PREFIX"]}__#{field}" : :"#{field}"
+        SalesforceArSync.config['NAMESPACE_PREFIX'].present? ? :"#{SalesforceArSync.config['NAMESPACE_PREFIX']}__#{field}" : :"#{field}"
       end
-    
+
+      # Get configuration for the in app deletions.
+      # Map to the object within the app if named differently then in SalesForce
+      def self.deletion_map(field)
+        SalesforceArSync.config['DELETION_MAP'].fetch(field, field)
+      end
+
       private
 
       def collect_sobjects
-        notification = @xml_hashed["Envelope"]["Body"]["notifications"]["Notification"] 
+        notification = @xml_hashed['Envelope']['Body']['notifications']['Notification']
         if notification.is_a? Array
-          return notification.collect{ |h| h["sObject"].symbolize_keys}
+          notification.collect { |h| h['sObject'].symbolize_keys }
         else
-          return [notification["sObject"].try(:symbolize_keys)]
+          [notification['sObject'].try(:symbolize_keys)]
         end
       end
     end

--- a/lib/salesforce_ar_sync/soap_handler/delete.rb
+++ b/lib/salesforce_ar_sync/soap_handler/delete.rb
@@ -1,19 +1,21 @@
 module SalesforceArSync
   module SoapHandler
     class Delete < SalesforceArSync::SoapHandler::Base
-       def process_notifications(priority = 90)
-         batch_process do |sobject|
-           SalesforceArSync::SoapHandler::Delete.delay(:priority => priority, :run_at => 5.seconds.from_now).delete_object(sobject)
-         end
-       end
+      def process_notifications(priority = 90)
+        batch_process do |sobject|
+          SalesforceArSync::SoapHandler::Delete.delay(priority: priority, run_at: 5.seconds.from_now).delete_object(sobject)
+        end
+      end
 
-       def self.delete_object(hash = {})
-         raise ArgumentError, "Object_Id__c parameter required" if hash[namespaced(:Object_Id__c)].blank?
-         raise ArgumentError, "Object_Type__c parameter required" if hash[namespaced(:Object_Type__c)].blank?
-     
-         object = hash[namespaced(:Object_Type__c)].constantize.find_by_salesforce_id(hash[namespaced(:Object_Id__c)])
-         object.destroy if object && object.ar_sync_inbound_delete?
-       end
+      def self.delete_object(hash = {})
+        raise ArgumentError, 'Object_Id__c parameter required' if hash[namespaced(:Object_Id__c)].blank?
+        raise ArgumentError, 'Object_Type__c parameter required' if hash[namespaced(:Object_Type__c)].blank?
+        raise Exception, "Deletion failed: No class found for #{hash[namespaced(:Object_Type__c)]}" unless deletion_map(hash[namespaced(:Object_Type__c)]).safe_constantize
+
+        object = deletion_map(hash[namespaced(:Object_Type__c)]).safe_constantize.try(:find_by_salesforce_id, hash[namespaced(:Object_Id__c)])
+
+        object.destroy if object && object.ar_sync_inbound_delete?
+      end
     end
-   end
- end
+  end
+end

--- a/lib/salesforce_ar_sync/version.rb
+++ b/lib/salesforce_ar_sync/version.rb
@@ -1,3 +1,3 @@
 module SalesforceArSync
-  VERSION = "2.0.0"
+  VERSION = '2.0.0'
 end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -1,5 +1,5 @@
-ActiveRecord::Schema.define(:version => 1) do
-  create_table "contacts", :force => true do |t|
+ActiveRecord::Schema.define(version: 1) do
+  create_table 'contacts', force: true do |t|
     t.string :first_name
     t.string :last_name
     t.string :phone
@@ -8,18 +8,27 @@ ActiveRecord::Schema.define(:version => 1) do
     t.datetime :salesforce_updated_at
     t.string :sync_inbound_delete
     t.string :sync_outbound_delete
-    t.timestamps
+    t.timestamps null: false
   end
 
-  create_table "users", :force => true do |t|
-    t.timestamps
+  create_table 'vendors', force: true do |t|
+    t.string :name
+    t.string :salesforce_id
+    t.datetime :salesforce_updated_at
+    t.string :sync_inbound_delete
+    t.string :sync_outbound_delete
+    t.timestamps null: false
   end
 
-  create_table "delete_tests", :force => true do |t|
-    t.timestamps
+  create_table 'users', force: true do |t|
+    t.timestamps null: false
   end
 
-  create_table "sync_tests", :force => true do |t|
-    t.timestamps
+  create_table 'delete_tests', force: true do |t|
+    t.timestamps null: false
+  end
+
+  create_table 'sync_tests', force: true do |t|
+    t.timestamps null: false
   end
 end

--- a/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
+++ b/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
@@ -1,19 +1,19 @@
 require 'spec_helper.rb'
 
-#for testing our environment variables
-SalesforceArSync.config = Hash.new
-SalesforceArSync.config["ORGANIZATION_ID"] = "123456789123456789"
-SalesforceArSync.config["SYNC_ENABLED"] = true
+# for testing our environment variables
+SalesforceArSync.config = {}
+SalesforceArSync.config['ORGANIZATION_ID'] = '123456789123456789'
+SalesforceArSync.config['SYNC_ENABLED'] = true
 
 class Contact < ActiveRecord::Base
-  salesforce_syncable :sync_attributes => {:FirstName => :first_name, :LastName => :last_name, :Phone => :phone_number, :Email => :email_address}
+  salesforce_syncable sync_attributes: { FirstName: :first_name, LastName: :last_name, Phone: :phone_number, Email: :email_address }
 
   def phone_number=(new_phone_number)
     self.phone = new_phone_number
   end
 
   def email_address
-    self.email
+    email
   end
 
   def email_address_changed?
@@ -22,30 +22,30 @@ class Contact < ActiveRecord::Base
 
   # Hack for Parsing into the proper Timezone
   def salesforce_updated_at=(updated_at)
-    updated_at = Time.parse(updated_at) if updated_at.present? && updated_at.kind_of?(String)
+    updated_at = Time.parse(updated_at) if updated_at.present? && updated_at.is_a?(String)
     write_attribute(:salesforce_updated_at, updated_at)
   end
 end
 
 # the following hash should match the data in SF.com you are testing against
 sample_outbound_message_hash = {
-  :Id => '003A0000014dbEeIAI',
-  :FirstName => 'Rose',
-  :LastName => 'Gonzalez',
-  :Phone => '(512) 757-6000',
-  :SystemModstamp => '2012-03-26T19:54:50.000Z',
-  :WebId__c => 68836
+  Id: '003A0000014dbEeIAI',
+  FirstName: 'Rose',
+  LastName: 'Gonzalez',
+  Phone: '(512) 757-6000',
+  SystemModstamp: '2012-03-26T19:54:50.000Z',
+  WebId__c: 68_836
 }
 
 # this message is missing the Phone field on purpose
 # Salesforce does not include empty fields  in the body
 # of an outbound message
 sample_partial_outbound_message_hash = {
-  :Id => '003A0000014dbEeIAI',
-  :FirstName => 'Rose',
-  :LastName => 'Gonzalez',
-  :SystemModstamp => '2012-03-26T19:54:50.000Z',
-  :WebId__c => 68836
+  Id: '003A0000014dbEeIAI',
+  FirstName: 'Rose',
+  LastName: 'Gonzalez',
+  SystemModstamp: '2012-03-26T19:54:50.000Z',
+  WebId__c: 68_836
 }
 
 describe SalesforceArSync, :vcr do
@@ -54,31 +54,31 @@ describe SalesforceArSync, :vcr do
       include ActiveModel::Validations::Callbacks
       extend SalesforceArSync::Extenders::SalesforceSyncable
 
-      salesforce_syncable :salesforce_sync_enabled => false,
-        :sync_attributes => {:FirstName => :first_name, :LastName => :last_name},
-        :async_attributes => ["Last_Login__c", "Login_Count__c"],
-        :default_attributes_for_create => {:password_change_required => true},
-        :salesforce_id_attribute_name => :Id,
-        :web_id_attribute_name  => :WebId__c,
-        :activerecord_web_id_attribute_name => :web_id,
-        :salesforce_sync_web_id => false,
-        :web_class_name => 'Contact',
-        :salesforce_object_name => :salesforce_object_name_method_name,
-        :except => :except_method_name,
-        :sync_inbound_delete => false,
-        :sync_outbound_delete => :outbound_delete_method_name,
-        :unscoped_updates => false
+      salesforce_syncable salesforce_sync_enabled: false,
+                          sync_attributes: { FirstName: :first_name, LastName: :last_name },
+                          async_attributes: %w(Last_Login__c Login_Count__c),
+                          default_attributes_for_create: { password_change_required: true },
+                          salesforce_id_attribute_name: :Id,
+                          web_id_attribute_name: :WebId__c,
+                          activerecord_web_id_attribute_name: :web_id,
+                          salesforce_sync_web_id: false,
+                          web_class_name: 'Contact',
+                          salesforce_object_name: :salesforce_object_name_method_name,
+                          except: :except_method_name,
+                          sync_inbound_delete: false,
+                          sync_outbound_delete: :outbound_delete_method_name,
+                          unscoped_updates: false
     end
 
     it 'should assign values from the options hash to model attributes' do
       expect(TestSyncable.salesforce_sync_enabled).to eq(false)
-      expect(TestSyncable.salesforce_sync_attribute_mapping).to eq({"FirstName" => :first_name, "LastName" => :last_name})
-      expect(TestSyncable.salesforce_async_attributes).to eq(["Last_Login__c", "Login_Count__c"])
-      expect(TestSyncable.salesforce_default_attributes_for_create).to eq({:password_change_required => true})
+      expect(TestSyncable.salesforce_sync_attribute_mapping).to eq('FirstName' => :first_name, 'LastName' => :last_name)
+      expect(TestSyncable.salesforce_async_attributes).to eq(%w(Last_Login__c Login_Count__c))
+      expect(TestSyncable.salesforce_default_attributes_for_create).to eq(password_change_required: true)
       expect(TestSyncable.salesforce_id_attribute_name).to eq(:Id)
       expect(TestSyncable.salesforce_web_id_attribute_name).to eq(:WebId__c)
       expect(TestSyncable.activerecord_web_id_attribute_name).to eq(:web_id)
-      expect(TestSyncable.salesforce_web_class_name).to eq("Contact")
+      expect(TestSyncable.salesforce_web_class_name).to eq('Contact')
       expect(TestSyncable.salesforce_object_name_method).to eq(:salesforce_object_name_method_name)
       expect(TestSyncable.salesforce_skip_sync_method).to eq(:except_method_name)
       expect(TestSyncable.sync_inbound_delete).to eq(false)
@@ -98,9 +98,10 @@ describe SalesforceArSync, :vcr do
 
   describe '.salesforce_update' do
     it 'should raise an exception if the salesforce id is blank' do
-      expect { Contact.salesforce_update(:Id => '', :FirstName => 'Bob') }.to raise_exception(ArgumentError)
-      expect { Contact.salesforce_update(:FirstName => 'Bob')}.to raise_exception(ArgumentError)
+      expect { Contact.salesforce_update(Id: '', FirstName: 'Bob') }.to raise_exception(ArgumentError)
+      expect { Contact.salesforce_update(FirstName: 'Bob') }.to raise_exception(ArgumentError)
     end
+
     it 'looks for records matching salesforce id' do
       sf_id = 1
 
@@ -110,6 +111,7 @@ describe SalesforceArSync, :vcr do
       expect(Contact).to receive(:find_by).with(salesforce_id: sf_id)
       Contact.salesforce_update(Id: sf_id)
     end
+
     it 'looks for records matching salesforce or web id' do
       sf_id = 1
       web_id = 20
@@ -121,6 +123,7 @@ describe SalesforceArSync, :vcr do
       expect(Contact).to receive(:find_by).with(id: web_id)
       Contact.salesforce_update(Id: sf_id, WebId__c: web_id)
     end
+
     it 'looks for records matching salesforce id or with a custom field matching web id' do
       sf_id = 1
       web_id = 20
@@ -146,52 +149,51 @@ describe SalesforceArSync, :vcr do
 
       Contact.salesforce_update(Id: sf_id)
     end
-
   end
 
   describe '.salesforce_id_attribute_name' do
-    it "returns the salesforce Id attribute name" do
+    it 'returns the salesforce Id attribute name' do
       expect(Contact.salesforce_id_attribute_name).to eq(:Id)
     end
   end
 
   describe '.salesforce_sync_web_id?' do
-    it "should default to false" do
+    it 'should default to false' do
       expect(Contact.salesforce_sync_web_id?).to be_falsey
     end
   end
 
   describe '.salesforce_web_id_attribute_name' do
-    it "should default to 'WebId__c'" do
+    it 'should default to "WebId__c"' do
       expect(Contact.salesforce_web_id_attribute_name).to eq(:WebId__c)
     end
   end
 
   describe '.salesforce_default_attributes_for_create' do
-    it "should default to an empty hash" do
+    it 'should default to an empty hash' do
       expect(Contact.salesforce_default_attributes_for_create).to eq({})
     end
   end
 
   describe '#salesforce_object_name' do
-    it "returns the current class name" do
-      expect(Contact.new.salesforce_object_name).to eq("Contact")
+    it 'returns the current class name' do
+      expect(Contact.new.salesforce_object_name).to eq('Contact')
     end
 
-    it "calls a method if one is provided" do
+    it 'calls a method if one is provided' do
       class User < ActiveRecord::Base
         include ActiveModel::Validations::Callbacks
         extend SalesforceArSync::Extenders::SalesforceSyncable
 
-        salesforce_syncable :salesforce_object_name => :custom_name
+        salesforce_syncable salesforce_object_name: :custom_name
 
         def custom_name
-          "CustomUser"
+          'CustomUser'
         end
       end
 
       user = User.new
-      expect(user.salesforce_object_name).to eq("CustomUser")
+      expect(user.salesforce_object_name).to eq('CustomUser')
     end
   end
 
@@ -206,7 +208,7 @@ describe SalesforceArSync, :vcr do
 
     context 'sync_inbound_delete set to true' do
       it 'should return true' do
-        contact = Contact.new(:sync_inbound_delete => true)
+        contact = Contact.new(sync_inbound_delete: true)
 
         expect(contact.ar_sync_inbound_delete?).to be_truthy
       end
@@ -218,10 +220,10 @@ describe SalesforceArSync, :vcr do
           include ActiveModel::Validations::Callbacks
           extend SalesforceArSync::Extenders::SalesforceSyncable
 
-          salesforce_syncable :sync_inbound_delete => :sync_delete
+          salesforce_syncable sync_inbound_delete: :sync_delete
 
           def sync_delete
-            return true
+            true
           end
         end
 
@@ -242,7 +244,7 @@ describe SalesforceArSync, :vcr do
 
     context 'sync_outbound_delete set to false' do
       it 'should return false' do
-        contact = Contact.new(:sync_outbound_delete => false)
+        contact = Contact.new(sync_outbound_delete: false)
 
         expect(contact.ar_sync_outbound_delete?).to be_falsey
       end
@@ -254,10 +256,10 @@ describe SalesforceArSync, :vcr do
           include ActiveModel::Validations::Callbacks
           extend SalesforceArSync::Extenders::SalesforceSyncable
 
-          salesforce_syncable :sync_outbound_delete => :sync_delete
+          salesforce_syncable sync_outbound_delete: :sync_delete
 
           def sync_delete
-            return false
+            false
           end
         end
 
@@ -276,17 +278,17 @@ describe SalesforceArSync, :vcr do
 
     context 'when SYNC_ENABLED is false in the global SalesforceArSync.config hash' do
       it 'should return true' do
-        SalesforceArSync.config["SYNC_ENABLED"] = false;
+        SalesforceArSync.config['SYNC_ENABLED'] = false
 
         expect(Contact.new.salesforce_skip_sync?).to be_truthy
 
-        SalesforceArSync.config["SYNC_ENABLED"] = true;
+        SalesforceArSync.config['SYNC_ENABLED'] = true
       end
     end
 
     context 'when salesforce_skip_sync is true on an object' do
       it 'returns true' do
-        contact = Contact.new(:salesforce_skip_sync => true)
+        contact = Contact.new(salesforce_skip_sync: true)
 
         expect(contact.salesforce_skip_sync?).to be_truthy
       end
@@ -298,7 +300,7 @@ describe SalesforceArSync, :vcr do
           include ActiveModel::Validations::Callbacks
           extend SalesforceArSync::Extenders::SalesforceSyncable
 
-          salesforce_syncable :salesforce_sync_enabled => false
+          salesforce_syncable salesforce_sync_enabled: false
         end
 
         sync_test = SyncTest.new
@@ -310,10 +312,10 @@ describe SalesforceArSync, :vcr do
           include ActiveModel::Validations::Callbacks
           extend SalesforceArSync::Extenders::SalesforceSyncable
 
-          salesforce_syncable :salesforce_sync_enabled => false
+          salesforce_syncable salesforce_sync_enabled: false
         end
 
-        sync_test = SyncTest.new(:salesforce_skip_sync => true)
+        sync_test = SyncTest.new(salesforce_skip_sync: true)
         expect(sync_test.salesforce_skip_sync?).to be_truthy
       end
     end
@@ -324,10 +326,10 @@ describe SalesforceArSync, :vcr do
           include ActiveModel::Validations::Callbacks
           extend SalesforceArSync::Extenders::SalesforceSyncable
 
-          salesforce_syncable :except => :custom_sync
+          salesforce_syncable except: :custom_sync
 
           def custom_sync
-            return true
+            true
           end
         end
 
@@ -340,14 +342,14 @@ describe SalesforceArSync, :vcr do
           include ActiveModel::Validations::Callbacks
           extend SalesforceArSync::Extenders::SalesforceSyncable
 
-          salesforce_syncable :except => :custom_sync, :salesforce_sync_enabled => false
+          salesforce_syncable except: :custom_sync, salesforce_sync_enabled: false
 
           def custom_sync
-            return false
+            false
           end
         end
 
-        sync_test = SyncTest.new()
+        sync_test = SyncTest.new
         expect(sync_test.salesforce_skip_sync?).to be_truthy
       end
 
@@ -356,21 +358,20 @@ describe SalesforceArSync, :vcr do
           include ActiveModel::Validations::Callbacks
           extend SalesforceArSync::Extenders::SalesforceSyncable
 
-          salesforce_syncable :except => :custom_sync
+          salesforce_syncable except: :custom_sync
 
           def custom_sync
-            return false
+            false
           end
         end
 
-        sync_test = SyncTest.new(:salesforce_skip_sync => true)
+        sync_test = SyncTest.new(salesforce_skip_sync: true)
         expect(sync_test.salesforce_skip_sync?).to be_truthy
       end
     end
   end
 
   describe '#salesforce_attributes_to_set' do
-
     before(:each) do
       @hash = Contact.new.salesforce_attributes_to_set(sample_outbound_message_hash)
     end
@@ -394,19 +395,18 @@ describe SalesforceArSync, :vcr do
     end
 
     it 'removes any attribute mapped to "id" as we do not want to set our primary key' do
-      allow(Contact).to receive(:salesforce_sync_attribute_mapping).and_return({"WebId__c" => "Id"})
+      allow(Contact).to receive(:salesforce_sync_attribute_mapping).and_return('WebId__c' => 'Id')
       contact = Contact.new
 
       contact.salesforce_attributes_to_set(sample_outbound_message_hash).tap do |hash|
         expect(hash[:first_name]).to be_nil
       end
     end
-
   end
 
   describe '#salesforce_process_update' do
     it 'should update and save record with values passed in to hash' do
-      contact = Contact.new(:first_name => "Bob", :last_name => "Smith")
+      contact = Contact.new(first_name: 'Bob', last_name: 'Smith')
       contact.salesforce_skip_sync = true
       contact.save!
       contact.salesforce_process_update(sample_outbound_message_hash)
@@ -419,7 +419,7 @@ describe SalesforceArSync, :vcr do
     end
 
     it 'should nil out any values not specified in the message from Salesforce' do
-      contact = Contact.new(:first_name => "Bob", :last_name => "Smith", :phone => '5195556677')
+      contact = Contact.new(first_name: 'Bob', last_name: 'Smith', phone: '5195556677')
       contact.salesforce_skip_sync = true
       contact.save!
       contact.salesforce_process_update(sample_partial_outbound_message_hash)
@@ -435,39 +435,42 @@ describe SalesforceArSync, :vcr do
   describe '#salesforce_attributes_to_update' do
     context 'when passing include_all as true' do
       it 'returns a hash of all attributes and values included in mapping that have getter methods' do
-        contact = Contact.create(:first_name => "Bob", :last_name => "Smith", :phone => "519 555-1212", :email => "bsmith@example.com", :salesforce_skip_sync => true)
-        contact.first_name = "Bill"
+        contact = Contact.create(first_name: 'Bob', last_name: 'Smith', phone: '519 555-1212', email: 'bsmith@example.com', salesforce_skip_sync: true)
+        contact.first_name = 'Bill'
         contact.salesforce_attributes_to_update(true).tap do |hash|
-          expect(hash["FirstName"]).to eq("Bill")
-          expect(hash["LastName"]).to eq("Smith")
-          expect(hash["Email"]).to eq("bsmith@example.com")
+          expect(hash['FirstName']).to eq('Bill')
+          expect(hash['LastName']).to eq('Smith')
+          expect(hash['Email']).to eq('bsmith@example.com')
         end
       end
     end
+
     context 'when passing include_all as false' do
       it 'returns a hash of changed attributes and values included in mapping that have getter methods' do
-        contact = Contact.create(:first_name => "Bob", :last_name => "Smith", :phone => "519 555-1212", :email => "bsmith@example.com", :salesforce_skip_sync => true)
-        contact.first_name = "Bill"
+        contact = Contact.create(first_name: 'Bob', last_name: 'Smith', phone: '519 555-1212', email: 'bsmith@example.com', salesforce_skip_sync: true)
+        contact.first_name = 'Bill'
         contact.salesforce_attributes_to_update(true).tap do |hash|
-          expect(hash["FirstName"]).to eq("Bill")
+          expect(hash['FirstName']).to eq('Bill')
         end
       end
     end
   end
+
   describe '#get_activerecord_web_id' do
     context 'no custom web id' do
       it 'returns the id' do
         contact = Contact.new(id: 1)
-        expect(contact.get_activerecord_web_id).to eq 1
+        expect(contact.get_activerecord_web_id).to eq(1)
       end
     end
+
     context 'custom web id' do
       it 'returns the id' do
-        contact = Contact.new(id: 1, last_name: "Johnson")
+        contact = Contact.new(id: 1, last_name: 'Johnson')
         allow(Contact).to receive(:salesforce_sync_web_id?).and_return(true)
         allow(Contact).to receive(:activerecord_web_id_attribute_name).and_return(:last_name)
 
-        expect(contact.get_activerecord_web_id).to eq "Johnson"
+        expect(contact.get_activerecord_web_id).to eq('Johnson')
       end
     end
   end

--- a/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
+++ b/spec/salesforce_ar_sync/salesforce_ar_sync_spec.rb
@@ -28,25 +28,25 @@ class Contact < ActiveRecord::Base
 end
 
 # the following hash should match the data in SF.com you are testing against
-sample_outbound_message_hash = {
+SAMPLE_OUTBOUND_MESSAGE_HASH = {
   Id: '003A0000014dbEeIAI',
   FirstName: 'Rose',
   LastName: 'Gonzalez',
   Phone: '(512) 757-6000',
   SystemModstamp: '2012-03-26T19:54:50.000Z',
   WebId__c: 68_836
-}
+}.freeze
 
 # this message is missing the Phone field on purpose
 # Salesforce does not include empty fields  in the body
 # of an outbound message
-sample_partial_outbound_message_hash = {
+SAMPLE_PARTIAL_OUTBOUND_MESSAGE_HASH = {
   Id: '003A0000014dbEeIAI',
   FirstName: 'Rose',
   LastName: 'Gonzalez',
   SystemModstamp: '2012-03-26T19:54:50.000Z',
   WebId__c: 68_836
-}
+}.freeze
 
 describe SalesforceArSync, :vcr do
   describe 'salesforce_syncable' do
@@ -373,21 +373,21 @@ describe SalesforceArSync, :vcr do
 
   describe '#salesforce_attributes_to_set' do
     before(:each) do
-      @hash = Contact.new.salesforce_attributes_to_set(sample_outbound_message_hash)
+      @hash = Contact.new.salesforce_attributes_to_set(SAMPLE_OUTBOUND_MESSAGE_HASH)
     end
 
     it 'hash should include salesforce_updated_at' do
-      expect(@hash[:salesforce_updated_at]).to eq(sample_outbound_message_hash[:SystemModstamp])
+      expect(@hash[:salesforce_updated_at]).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:SystemModstamp])
     end
 
     it 'hash should include salesforce_id' do
-      expect(@hash[:salesforce_id]).to eq(sample_outbound_message_hash[:Id])
+      expect(@hash[:salesforce_id]).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:Id])
     end
 
     it 'hash should only include keys and values in the mapping that we have setters for' do
-      expect(@hash[:first_name]).to eq(sample_outbound_message_hash[:FirstName])
-      expect(@hash[:last_name]).to eq(sample_outbound_message_hash[:LastName])
-      expect(@hash[:phone_number]).to eq(sample_outbound_message_hash[:Phone])
+      expect(@hash[:first_name]).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:FirstName])
+      expect(@hash[:last_name]).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:LastName])
+      expect(@hash[:phone_number]).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:Phone])
     end
 
     it 'hash should only include 5 keys' do
@@ -398,7 +398,7 @@ describe SalesforceArSync, :vcr do
       allow(Contact).to receive(:salesforce_sync_attribute_mapping).and_return('WebId__c' => 'Id')
       contact = Contact.new
 
-      contact.salesforce_attributes_to_set(sample_outbound_message_hash).tap do |hash|
+      contact.salesforce_attributes_to_set(SAMPLE_OUTBOUND_MESSAGE_HASH).tap do |hash|
         expect(hash[:first_name]).to be_nil
       end
     end
@@ -409,26 +409,26 @@ describe SalesforceArSync, :vcr do
       contact = Contact.new(first_name: 'Bob', last_name: 'Smith')
       contact.salesforce_skip_sync = true
       contact.save!
-      contact.salesforce_process_update(sample_outbound_message_hash)
+      contact.salesforce_process_update(SAMPLE_OUTBOUND_MESSAGE_HASH)
 
-      expect(contact.first_name).to eq(sample_outbound_message_hash[:FirstName])
-      expect(contact.last_name).to eq(sample_outbound_message_hash[:LastName])
-      expect(contact.phone).to eq(sample_outbound_message_hash[:Phone])
-      expect(contact.salesforce_id).to eq(sample_outbound_message_hash[:Id])
-      expect(contact.salesforce_updated_at).to eq(Time.parse(sample_outbound_message_hash[:SystemModstamp]))
+      expect(contact.first_name).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:FirstName])
+      expect(contact.last_name).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:LastName])
+      expect(contact.phone).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:Phone])
+      expect(contact.salesforce_id).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:Id])
+      expect(contact.salesforce_updated_at).to eq(Time.parse(SAMPLE_OUTBOUND_MESSAGE_HASH[:SystemModstamp]))
     end
 
     it 'should nil out any values not specified in the message from Salesforce' do
       contact = Contact.new(first_name: 'Bob', last_name: 'Smith', phone: '5195556677')
       contact.salesforce_skip_sync = true
       contact.save!
-      contact.salesforce_process_update(sample_partial_outbound_message_hash)
+      contact.salesforce_process_update(SAMPLE_PARTIAL_OUTBOUND_MESSAGE_HASH)
 
       expect(contact.phone).to be_nil
-      expect(contact.first_name).to eq(sample_outbound_message_hash[:FirstName])
-      expect(contact.last_name).to eq(sample_outbound_message_hash[:LastName])
-      expect(contact.salesforce_id).to eq(sample_outbound_message_hash[:Id])
-      expect(contact.salesforce_updated_at).to eq(Time.parse(sample_outbound_message_hash[:SystemModstamp]))
+      expect(contact.first_name).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:FirstName])
+      expect(contact.last_name).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:LastName])
+      expect(contact.salesforce_id).to eq(SAMPLE_OUTBOUND_MESSAGE_HASH[:Id])
+      expect(contact.salesforce_updated_at).to eq(Time.parse(SAMPLE_OUTBOUND_MESSAGE_HASH[:SystemModstamp]))
     end
   end
 

--- a/spec/salesforce_ar_sync/soap_handlers/delete_spec.rb
+++ b/spec/salesforce_ar_sync/soap_handlers/delete_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper.rb'
+
+# for testing our environment variables
+SalesforceArSync.config = {}
+SalesforceArSync.config['ORGANIZATION_ID'] = '123456789123456789'
+SalesforceArSync.config['SYNC_ENABLED'] = true
+SalesforceArSync.config['DELETION_MAP'] = { 'Account' => 'Vendor' }
+
+delete_hsh = {
+  Id: '003A0000014dbEeIAJ',
+  Object_Id__c: '003A0000014dbEeIAI',
+  Object_Type__c: 'Account'
+}
+
+delete_hsh_without_id = {
+  Id: '003A0000014dbEeIAJ',
+  Object_Id__c: '',
+  Object_Type__c: 'Account'
+}
+
+delete_hsh_without_type = {
+  Id: '003A0000014dbEeIAJ',
+  Object_Id__c: '003A0000014dbEeIAI',
+  Object_Type__c: ''
+}
+
+delete_hsh_with_unknown_type = {
+  Id: '003A0000014dbEeIAJ',
+  Object_Id__c: '003A0000014dbEeIAI',
+  Object_Type__c: 'Unknown'
+}
+
+# Actually maps to Account
+class Vendor < ActiveRecord::Base
+  salesforce_syncable sync_attributes: { Name: :name, salesforce_object_name: :Account }
+end
+
+describe SalesforceArSync::SoapHandler::Delete do
+  describe 'self.delete_object' do
+    it 'should raise an argument error if missing the object id' do
+      expect { SalesforceArSync::SoapHandler::Delete.delete_object(delete_hsh_without_id) }.to raise_error(ArgumentError)
+    end
+
+    it 'should raise an argument error if missing the object type' do
+      expect { SalesforceArSync::SoapHandler::Delete.delete_object(delete_hsh_without_type) }.to raise_error(ArgumentError)
+    end
+
+    it 'should raise an exception if the class can\'t be found' do
+      expect { SalesforceArSync::SoapHandler::Delete.delete_object(delete_hsh_with_unknown_type) }.to raise_error(Exception)
+    end
+
+    it 'should delete a Vendor' do
+      Vendor.create(name: 'Test Inc.', salesforce_skip_sync: true, salesforce_id: '003A0000014dbEeIAI')
+      expect { SalesforceArSync::SoapHandler::Delete.delete_object(delete_hsh) }.to change { Vendor.all.size }.by(-1)
+    end
+
+    it 'should not fail if the object can\'t be found' do
+      Vendor.create(name: 'Test Inc.', salesforce_skip_sync: true, salesforce_id: '003A0000014dbEeIAL')
+      expect { SalesforceArSync::SoapHandler::Delete.delete_object(delete_hsh) }.to_not change { Vendor.all.size }
+    end
+  end
+end

--- a/spec/salesforce_ar_sync/soap_handlers/delete_spec.rb
+++ b/spec/salesforce_ar_sync/soap_handlers/delete_spec.rb
@@ -6,29 +6,35 @@ SalesforceArSync.config['ORGANIZATION_ID'] = '123456789123456789'
 SalesforceArSync.config['SYNC_ENABLED'] = true
 SalesforceArSync.config['DELETION_MAP'] = { 'Account' => 'Vendor' }
 
-delete_hsh = {
+DELETE_HSH = {
   Id: '003A0000014dbEeIAJ',
   Object_Id__c: '003A0000014dbEeIAI',
   Object_Type__c: 'Account'
-}
+}.freeze
 
-delete_hsh_without_id = {
+CONTACT_DELETE_HSH = {
+  Id: '003A0000014dbEeIAJ',
+  Object_Id__c: '003A0000014dbEeIAI',
+  Object_Type__c: 'Contact'
+}.freeze
+
+DELETE_HSH_WITHOUT_ID = {
   Id: '003A0000014dbEeIAJ',
   Object_Id__c: '',
   Object_Type__c: 'Account'
-}
+}.freeze
 
-delete_hsh_without_type = {
+DELETE_HSH_WITHOUT_TYPE = {
   Id: '003A0000014dbEeIAJ',
   Object_Id__c: '003A0000014dbEeIAI',
   Object_Type__c: ''
-}
+}.freeze
 
-delete_hsh_with_unknown_type = {
+DELETE_HSH_WITH_UNKNOWN_TYPE = {
   Id: '003A0000014dbEeIAJ',
   Object_Id__c: '003A0000014dbEeIAI',
   Object_Type__c: 'Unknown'
-}
+}.freeze
 
 # Actually maps to Account
 class Vendor < ActiveRecord::Base
@@ -37,26 +43,62 @@ end
 
 describe SalesforceArSync::SoapHandler::Delete do
   describe 'self.delete_object' do
-    it 'should raise an argument error if missing the object id' do
-      expect { SalesforceArSync::SoapHandler::Delete.delete_object(delete_hsh_without_id) }.to raise_error(ArgumentError)
+    context 'with delete config' do
+      before :each do
+        SalesforceArSync.config = {}
+        SalesforceArSync.config['ORGANIZATION_ID'] = '123456789123456789'
+        SalesforceArSync.config['SYNC_ENABLED'] = true
+        SalesforceArSync.config['DELETION_MAP'] = { 'Account' => 'Vendor' }
+      end
+
+      it 'should raise an argument error if missing the object id' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITHOUT_ID) }.to raise_error(ArgumentError)
+      end
+
+      it 'should raise an argument error if missing the object type' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITHOUT_TYPE) }.to raise_error(ArgumentError)
+      end
+
+      it 'should raise an exception if the class can\'t be found' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITH_UNKNOWN_TYPE) }.to raise_error(Exception)
+      end
+
+      it 'should delete a Vendor' do
+        Vendor.create(name: 'Test Inc.', salesforce_skip_sync: true, salesforce_id: '003A0000014dbEeIAI')
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH) }.to change { Vendor.all.size }.by(-1)
+      end
+
+      it 'should not fail if the object can\'t be found' do
+        Vendor.create(name: 'Test Inc.', salesforce_skip_sync: true, salesforce_id: '003A0000014dbEeIAL')
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH) }.to_not change { Vendor.all.size }
+      end
     end
 
-    it 'should raise an argument error if missing the object type' do
-      expect { SalesforceArSync::SoapHandler::Delete.delete_object(delete_hsh_without_type) }.to raise_error(ArgumentError)
-    end
+    describe 'without delete config' do
+      before :each do
+        SalesforceArSync.config = {}
+        SalesforceArSync.config['ORGANIZATION_ID'] = '123456789123456789'
+        SalesforceArSync.config['SYNC_ENABLED'] = true
+        SalesforceArSync.config['DELETION_MAP'] = {}
+      end
 
-    it 'should raise an exception if the class can\'t be found' do
-      expect { SalesforceArSync::SoapHandler::Delete.delete_object(delete_hsh_with_unknown_type) }.to raise_error(Exception)
-    end
+      it 'should raise an argument error if missing the object id' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITHOUT_ID) }.to raise_error(ArgumentError)
+      end
 
-    it 'should delete a Vendor' do
-      Vendor.create(name: 'Test Inc.', salesforce_skip_sync: true, salesforce_id: '003A0000014dbEeIAI')
-      expect { SalesforceArSync::SoapHandler::Delete.delete_object(delete_hsh) }.to change { Vendor.all.size }.by(-1)
-    end
+      it 'should raise an argument error if missing the object type' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITHOUT_TYPE) }.to raise_error(ArgumentError)
+      end
 
-    it 'should not fail if the object can\'t be found' do
-      Vendor.create(name: 'Test Inc.', salesforce_skip_sync: true, salesforce_id: '003A0000014dbEeIAL')
-      expect { SalesforceArSync::SoapHandler::Delete.delete_object(delete_hsh) }.to_not change { Vendor.all.size }
+      it 'should raise an exception if the class can\'t be found' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITH_UNKNOWN_TYPE) }.to raise_error(Exception)
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH) }.to raise_error(Exception)
+      end
+
+      it 'should delete a contact' do
+        Contact.create(first_name: 'Test', last_name: 'Test', salesforce_skip_sync: true, salesforce_id: '003A0000014dbEeIAI')
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(CONTACT_DELETE_HSH) }.to change { Contact.all.size }.by(-1)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,31 +8,32 @@ require 'ammeter/init'
 require 'vcr'
 
 # Configure Rails Environment
-ENV["RAILS_ENV"] = "test"
+ENV['RAILS_ENV'] = 'test'
 ENGINE_RAILS_ROOT=File.join(File.dirname(__FILE__), '../')
 plugin_test_dir = File.dirname(__FILE__)
 
 # Load sqlite3 mem database for testing
-ActiveRecord::Base.configurations = YAML::load_file(File.join(plugin_test_dir, "db", "database.yml"))
-ActiveRecord::Base.establish_connection((ENV["DB"] || "sqlite3mem").to_sym)
+ActiveRecord::Base.configurations = YAML::load_file(File.join(plugin_test_dir, 'db', 'database.yml'))
+ActiveRecord::Base.establish_connection((ENV['DB'] || 'sqlite3mem').to_sym)
 ActiveRecord::Migration.verbose = false
-load(File.join(plugin_test_dir, "db", "schema.rb"))
+load(File.join(plugin_test_dir, 'db', 'schema.rb'))
 
 VCR.configure do |c|
-  c.cassette_library_dir =  "vcr_cassettes"
+  c.cassette_library_dir = 'vcr_cassettes'
   c.hook_into :webmock
   c.ignore_localhost = true
   c.allow_http_connections_when_no_cassette = true
   c.default_cassette_options = {
-      :match_requests_on => [:method,
-        VCR.request_matchers.uri_without_param(:client_id, :client_secret, :username, :password)]
-    }
+    match_requests_on: [
+      :method,
+      VCR.request_matchers.uri_without_param(:client_id, :client_secret, :username, :password)]
+  }
 end
 
 RSpec.configure do |c|
-  #for each test that makes a request use a tape based on it's name
+  # for each test that makes a request use a tape based on it's name
   c.around(:each, :vcr) do |example|
-    name = example.metadata[:full_description].split(/\s+/, 2).join("/").underscore.gsub(/[^\w\/]+/, "_")
+    name = example.metadata[:full_description].split(/\s+/, 2).join('/').underscore.gsub(/[^\w\/]+/, "_")
     options = example.metadata.slice(:record, :match_requests_on).except(:example_group)
     VCR.use_cassette(name, options) { example.call }
   end

--- a/spec/support/delete_test_configs.yml
+++ b/spec/support/delete_test_configs.yml
@@ -1,0 +1,8 @@
+test:
+  organization_id: 00D560000000TeStAU
+  sync_enabled: true
+  ip_ranges:
+  namespace_prefix:
+  deletion_map:
+   -
+    Account: 'Vendor'


### PR DESCRIPTION
# WHAT
Deletes fail when SFDC sends for an object to delete that has a different name in the app. IE. `Account` has been aliased to `Vendor`.

# HOW
Added a salesforce_ar_sync.yml option to allow you to specify a map of SFDC objects to app objects.

# OTHER
Made a lot of Rubocop changes to the gem... I just had to!