### PR TITLE
Delete config pruned

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ gemfile:
   - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
 script: bundle exec rake spec
+before_install:
+  - gem install bundler

--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ initializer loads the ENV settings.
     $ export SALESFORCE_AR_NAMESPACE_PREFIX=my_prefix
 
 An example of adding an aliased object to the deletion map should look like the following:
+
     deletion_map:
-     - 
+     -
       Account: 'YourModelName'
 
 ### Model Options

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The options available to configure are
 * __organization_id__: the 18 character organization id of your Salesforce instance
 * __sync_enabled__: a global sync enabled flag which is a boolean true/false
 * __namespace_prefix__: Namespace prefix of your Salesforce app in case you specified one
+* __deletion_map__: Salesforce object names mapped to internal app name.
 
 To generate a YAML file
 
@@ -125,6 +126,7 @@ which will create a template salesforce_ar_sync.yml in /config that looks like t
     organization_id: <organization id> #18 character organization_id
     sync_enabled: true
     namespace_prefix:
+    deletion_map:
 
 
 To use the ENV variable you must pass environemnt variables to rails via the _export_ command in bash or before the
@@ -133,6 +135,11 @@ initializer loads the ENV settings.
     $ export SALESFORCE_AR_SYNC_ORGANIZATION_ID=123456789123456789
     $ export SALESFORCE_AR_SYNC_SYNC_ENABLED=true
     $ export SALESFORCE_AR_NAMESPACE_PREFIX=my_prefix
+
+An example of adding an aliased object to the deletion map should look like the following:
+    deletion_map:
+     - 
+      Account: 'YourModelName'
 
 ### Model Options
 The model can have several options set:

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "rails", "4.2.1"
+gem 'mime-types', '2.6.2'
 
 gemspec :path => "../"

--- a/lib/generators/salesforce_ar_sync/configuration/templates/salesforce_ar_sync.yml
+++ b/lib/generators/salesforce_ar_sync/configuration/templates/salesforce_ar_sync.yml
@@ -4,17 +4,20 @@ production:
   # Salesforce owned IPs from: https://help.salesforce.com/apex/HTViewSolution?language=en_US&id=000003652
   ip_ranges: "204.14.232.0/23,204.14.237.0/24,96.43.144.0/22,96.43.148.0/22,204.14.234.0/23,204.14.238.0/23,182.50.76.0/22"
   namespace_prefix:
-  
+  deletion_map:
+
 development:
   organization_id: <%= @organization_id %>
   sync_enabled: false
   # Salesforce owned IPs from: https://help.salesforce.com/apex/HTViewSolution?language=en_US&id=000003652
   ip_ranges: "204.14.232.0/23,204.14.237.0/24,96.43.144.0/22,96.43.148.0/22,204.14.234.0/23,204.14.238.0/23,182.50.76.0/22"
   namespace_prefix:
-    
+  deletion_map:
+
 test:
   organization_id: <%= @organization_id %>
   sync_enabled: false
   # Salesforce owned IPs from: https://help.salesforce.com/apex/HTViewSolution?language=en_US&id=000003652
   ip_ranges: "204.14.232.0/23,204.14.237.0/24,96.43.144.0/22,96.43.148.0/22,204.14.234.0/23,204.14.238.0/23,182.50.76.0/22"
   namespace_prefix:
+  deletion_map:

--- a/lib/salesforce_ar_sync/engine.rb
+++ b/lib/salesforce_ar_sync/engine.rb
@@ -3,7 +3,7 @@ module SalesforceArSync
     initializer "salesforce_ar_sync.load_app_instance_data" do |app|
       SalesforceArSync.setup do |config|
         config.app_root = app.root
-        
+
         #Load the configuration from the environment or a yaml file or disable it if no config present
         SalesforceArSync.config = Hash.new
         #load the config file if we have it
@@ -13,6 +13,7 @@ module SalesforceArSync
           SalesforceArSync.config["SYNC_ENABLED"] = config['sync_enabled']
           SalesforceArSync.config["IP_RANGES"] = config['ip_ranges'].split(',').map{ |ip| ip.strip }
           SalesforceArSync.config["NAMESPACE_PREFIX"] = config['namespace_prefix']
+          SalesforceArSync.config['DELETION_MAP'] = config['deletion_map'].stringify_keys
         end
 
         #if we have ENV flags prefer them
@@ -20,6 +21,7 @@ module SalesforceArSync
         SalesforceArSync.config["SYNC_ENABLED"] = ENV["SALESFORCE_AR_SYNC_SYNC_ENABLED"] if ENV.include? "SALESFORCE_AR_SYNC_SYNC_ENABLED"
         SalesforceArSync.config["IP_RANGES"] = ENV["SALESFORCE_AR_SYNC_IP_RANGES"].split(',').map{ |ip| ip.strip } if ENV["SALESFORCE_AR_SYNC_IP_RANGES"]
         SalesforceArSync.config["NAMESPACE_PREFIX"] = ENV["SALESFORCE_AR_NAMESPACE_PREFIX"] if ENV["SALESFORCE_AR_NAMESPACE_PREFIX"]
+        SalesforceArSync.config['DELETION_MAP'] = ENV['DELETION_MAP'] if ENV['DELETION_MAP']
 
         #do we have valid config options now?
         if !SalesforceArSync.config["ORGANIZATION_ID"].present? || SalesforceArSync.config["ORGANIZATION_ID"].length != 18

--- a/lib/salesforce_ar_sync/soap_handler/base.rb
+++ b/lib/salesforce_ar_sync/soap_handler/base.rb
@@ -34,9 +34,9 @@ module SalesforceArSync
 
       #xml for SFDC response
       #called from soap_message_controller
-      def generate_response(error = nil)      
+      def generate_response(error = nil)
         response = "<Ack>#{sobjects.nil? ? false : true}</Ack>" unless error
-        if error 
+        if error
           response = "<soapenv:Fault><faultcode>soap:Receiver</faultcode><faultstring>#{error.message}</faultstring></soapenv:Fault>"
         end
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><soapenv:Body><notificationsResponse>#{response}</notificationsResponse></soapenv:Body></soapenv:Envelope>"
@@ -45,11 +45,17 @@ module SalesforceArSync
       def self.namespaced(field)
          SalesforceArSync.config["NAMESPACE_PREFIX"].present? ? :"#{SalesforceArSync.config["NAMESPACE_PREFIX"]}__#{field}" : :"#{field}"
       end
-    
+
+      # Get configuration for the in app deletions.
+      # Map to the object within the app if named differently then in SalesForce
+      def self.deletion_map(field)
+        SalesforceArSync.config['DELETION_MAP'].fetch(field, field)
+      end
+
       private
 
       def collect_sobjects
-        notification = @xml_hashed["Envelope"]["Body"]["notifications"]["Notification"] 
+        notification = @xml_hashed["Envelope"]["Body"]["notifications"]["Notification"]
         if notification.is_a? Array
           return notification.collect{ |h| h["sObject"].symbolize_keys}
         else

--- a/lib/salesforce_ar_sync/soap_handler/delete.rb
+++ b/lib/salesforce_ar_sync/soap_handler/delete.rb
@@ -1,19 +1,21 @@
 module SalesforceArSync
   module SoapHandler
     class Delete < SalesforceArSync::SoapHandler::Base
-       def process_notifications(priority = 90)
-         batch_process do |sobject|
-           SalesforceArSync::SoapHandler::Delete.delay(:priority => priority, :run_at => 5.seconds.from_now).delete_object(sobject)
-         end
-       end
+      def process_notifications(priority = 90)
+        batch_process do |sobject|
+          SalesforceArSync::SoapHandler::Delete.delay(priority: priority, run_at: 5.seconds.from_now).delete_object(sobject)
+        end
+      end
 
-       def self.delete_object(hash = {})
-         raise ArgumentError, "Object_Id__c parameter required" if hash[namespaced(:Object_Id__c)].blank?
-         raise ArgumentError, "Object_Type__c parameter required" if hash[namespaced(:Object_Type__c)].blank?
-     
-         object = hash[namespaced(:Object_Type__c)].constantize.find_by_salesforce_id(hash[namespaced(:Object_Id__c)])
-         object.destroy if object && object.ar_sync_inbound_delete?
-       end
+      def self.delete_object(hash = {})
+        raise ArgumentError, 'Object_Id__c parameter required' if hash[namespaced(:Object_Id__c)].blank?
+        raise ArgumentError, 'Object_Type__c parameter required' if hash[namespaced(:Object_Type__c)].blank?
+        raise Exception, "Deletion failed: No class found for #{hash[namespaced(:Object_Type__c)]}" unless deletion_map(hash[namespaced(:Object_Type__c)]).safe_constantize
+
+        object = deletion_map(hash[namespaced(:Object_Type__c)]).safe_constantize.try(:find_by_salesforce_id, hash[namespaced(:Object_Id__c)])
+
+        object.destroy if object && object.ar_sync_inbound_delete?
+      end
     end
-   end
- end
+  end
+end

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -11,6 +11,15 @@ ActiveRecord::Schema.define(:version => 1) do
     t.timestamps
   end
 
+  create_table 'vendors', force: true do |t|
+    t.string :name
+    t.string :salesforce_id
+    t.datetime :salesforce_updated_at
+    t.string :sync_inbound_delete
+    t.string :sync_outbound_delete
+    t.timestamps null: false
+  end
+
   create_table "users", :force => true do |t|
     t.timestamps
   end

--- a/spec/salesforce_ar_sync/soap_handlers/delete_spec.rb
+++ b/spec/salesforce_ar_sync/soap_handlers/delete_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper.rb'
+
+# for testing our environment variables
+SalesforceArSync.config = {}
+SalesforceArSync.config['ORGANIZATION_ID'] = '123456789123456789'
+SalesforceArSync.config['SYNC_ENABLED'] = true
+SalesforceArSync.config['DELETION_MAP'] = { 'Account' => 'Vendor' }
+
+DELETE_HSH = {
+  Id: '003A0000014dbEeIAJ',
+  Object_Id__c: '003A0000014dbEeIAI',
+  Object_Type__c: 'Account'
+}.freeze
+
+CONTACT_DELETE_HSH = {
+  Id: '003A0000014dbEeIAJ',
+  Object_Id__c: '003A0000014dbEeIAI',
+  Object_Type__c: 'Contact'
+}.freeze
+
+DELETE_HSH_WITHOUT_ID = {
+  Id: '003A0000014dbEeIAJ',
+  Object_Id__c: '',
+  Object_Type__c: 'Account'
+}.freeze
+
+DELETE_HSH_WITHOUT_TYPE = {
+  Id: '003A0000014dbEeIAJ',
+  Object_Id__c: '003A0000014dbEeIAI',
+  Object_Type__c: ''
+}.freeze
+
+DELETE_HSH_WITH_UNKNOWN_TYPE = {
+  Id: '003A0000014dbEeIAJ',
+  Object_Id__c: '003A0000014dbEeIAI',
+  Object_Type__c: 'Unknown'
+}.freeze
+
+# Actually maps to Account
+class Vendor < ActiveRecord::Base
+  salesforce_syncable sync_attributes: { Name: :name, salesforce_object_name: :Account }
+end
+
+describe SalesforceArSync::SoapHandler::Delete do
+  describe 'self.delete_object' do
+    context 'with delete config' do
+      before :each do
+        SalesforceArSync.config = {}
+        SalesforceArSync.config['ORGANIZATION_ID'] = '123456789123456789'
+        SalesforceArSync.config['SYNC_ENABLED'] = true
+        SalesforceArSync.config['DELETION_MAP'] = { 'Account' => 'Vendor' }
+      end
+
+      it 'should raise an argument error if missing the object id' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITHOUT_ID) }.to raise_error(ArgumentError)
+      end
+
+      it 'should raise an argument error if missing the object type' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITHOUT_TYPE) }.to raise_error(ArgumentError)
+      end
+
+      it 'should raise an exception if the class can\'t be found' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITH_UNKNOWN_TYPE) }.to raise_error(Exception)
+      end
+
+      it 'should delete a Vendor' do
+        Vendor.create(name: 'Test Inc.', salesforce_skip_sync: true, salesforce_id: '003A0000014dbEeIAI')
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH) }.to change { Vendor.all.size }.by(-1)
+      end
+
+      it 'should not fail if the object can\'t be found' do
+        Vendor.create(name: 'Test Inc.', salesforce_skip_sync: true, salesforce_id: '003A0000014dbEeIAL')
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH) }.to_not change { Vendor.all.size }
+      end
+    end
+
+    describe 'without delete config' do
+      before :each do
+        SalesforceArSync.config = {}
+        SalesforceArSync.config['ORGANIZATION_ID'] = '123456789123456789'
+        SalesforceArSync.config['SYNC_ENABLED'] = true
+        SalesforceArSync.config['DELETION_MAP'] = {}
+      end
+
+      it 'should raise an argument error if missing the object id' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITHOUT_ID) }.to raise_error(ArgumentError)
+      end
+
+      it 'should raise an argument error if missing the object type' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITHOUT_TYPE) }.to raise_error(ArgumentError)
+      end
+
+      it 'should raise an exception if the class can\'t be found' do
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH_WITH_UNKNOWN_TYPE) }.to raise_error(Exception)
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(DELETE_HSH) }.to raise_error(Exception)
+      end
+
+      it 'should delete a contact' do
+        Contact.create(first_name: 'Test', last_name: 'Test', salesforce_skip_sync: true, salesforce_id: '003A0000014dbEeIAI')
+        expect { SalesforceArSync::SoapHandler::Delete.delete_object(CONTACT_DELETE_HSH) }.to change { Contact.all.size }.by(-1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# WHAT
Deletes fail when SFDC sends for an object to delete that has a different name in the app. IE. `Account` has been aliased to `Vendor`.

# HOW
Added a salesforce_ar_sync.yml option to allow you to specify a map of SFDC objects to app objects.

# OTHER
Made a lot of Rubocop changes to the gem... I just had to!