### PR TITLE
Rails5 web id sync

### DIFF
--- a/lib/salesforce_ar_sync/extenders/salesforce_syncable.rb
+++ b/lib/salesforce_ar_sync/extenders/salesforce_syncable.rb
@@ -30,7 +30,7 @@ module SalesforceArSync
           after_commit :salesforce_delete_object, on: :destroy
 
           def salesforce_sync_web_id?
-            self.salesforce_sync_web_id
+            SalesforceArSync.config["SYNC_ENABLED"] == true && self.salesforce_id.present? && self.salesforce_sync_web_id
           end
         end
 

--- a/lib/salesforce_ar_sync/extenders/salesforce_syncable.rb
+++ b/lib/salesforce_ar_sync/extenders/salesforce_syncable.rb
@@ -30,7 +30,7 @@ module SalesforceArSync
           after_commit :salesforce_delete_object, on: :destroy
 
           def salesforce_sync_web_id?
-            SalesforceArSync.config["SYNC_ENABLED"] == true && self.salesforce_id.present? && self.salesforce_sync_web_id
+            SalesforceArSync.config["SYNC_ENABLED"] == true && self.salesforce_sync_web_id
           end
         end
 

--- a/lib/salesforce_ar_sync/extenders/salesforce_syncable.rb
+++ b/lib/salesforce_ar_sync/extenders/salesforce_syncable.rb
@@ -30,7 +30,7 @@ module SalesforceArSync
           after_commit :salesforce_delete_object, on: :destroy
 
           def salesforce_sync_web_id?
-            SalesforceArSync.config["SYNC_ENABLED"] == true && self.salesforce_sync_web_id
+            self.salesforce_sync_web_id
           end
         end
 

--- a/lib/salesforce_ar_sync/salesforce_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_sync.rb
@@ -227,7 +227,7 @@ module SalesforceArSync
     end
 
     def sync_web_id
-      return false if !self.class.salesforce_sync_web_id?
+      return false if !self.class.salesforce_sync_web_id? || SalesforceArSync.config['SYNC_ENABLED'] == false
       SF_CLIENT.http_patch("/services/data/v#{SF_CLIENT.version}/sobjects/#{salesforce_object_name}/#{salesforce_id}", { self.class.salesforce_web_id_attribute_name.to_s => get_activerecord_web_id }.to_json) if salesforce_id
     end
 

--- a/lib/salesforce_ar_sync/salesforce_sync.rb
+++ b/lib/salesforce_ar_sync/salesforce_sync.rb
@@ -227,7 +227,7 @@ module SalesforceArSync
     end
 
     def sync_web_id
-      return false if !self.class.salesforce_sync_web_id? || salesforce_skip_sync?
+      return false if !self.class.salesforce_sync_web_id?
       SF_CLIENT.http_patch("/services/data/v#{SF_CLIENT.version}/sobjects/#{salesforce_object_name}/#{salesforce_id}", { self.class.salesforce_web_id_attribute_name.to_s => get_activerecord_web_id }.to_json) if salesforce_id
     end
 


### PR DESCRIPTION
Currently salesforce_update calls set the salesforce_skip_sync flag to true to avoid looping syncs between the client and salesforce.

The sync_web_id (run in an after_create hook) method doesn't sync if this flag is true.  Currently you can create a new syncable object in salesforce which is set to sync WebId and it won't sync back to SFDC.

Remove the check for salesforce_skip_sync during WebId syncing so this field will begin syncing properly.